### PR TITLE
Fix: Frame parser overflowed.

### DIFF
--- a/bin/varnishtest/h2tests/h2_1.vtc
+++ b/bin/varnishtest/h2tests/h2_1.vtc
@@ -1,0 +1,19 @@
+varnishtest "overflow"
+
+h2server s1 {
+	stream 1 {
+		rxreq
+		txresp -hdr long-header-original1 original1 \
+			-hdr long-header-original2 original2 \
+			-hdr long-header-original3 original3 \
+			-hdr long-header-original4 original4 
+	} -run
+} -start
+
+h2client c1  -connect ${s1_sock} {
+	stream 1 {
+		txreq -req GET -url / -hdr :scheme http -hdr :authority localhost
+		rxresp
+		expect resp.http.:status == 200
+	} -run
+} -run

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -279,18 +279,18 @@ readFrameHeader(struct frame *f, char *buf)
 	CHECK_OBJ_NOTNULL(f, FRAME_MAGIC);
 	AN(buf);
 
-	f->size  = buf[0] << 16;
-	f->size += buf[1] << 8;
-	f->size += buf[2];
+	f->size  = (unsigned char)buf[0] << 16;
+	f->size += (unsigned char)buf[1] << 8;
+	f->size += (unsigned char)buf[2];
 
-	f->type = buf[3];
+	f->type = (unsigned char)buf[3];
 
-	f->flags = buf[4];
+	f->flags = (unsigned char)buf[4];
 
-	f->stid  = (0xff & buf[5]) << 24;
-	f->stid += (0xff & buf[6]) << 16;
-	f->stid += (0xff & buf[7]) <<  8;
-	f->stid += (0xff & buf[8]);
+	f->stid  = (0xff & (unsigned char)buf[5]) << 24;
+	f->stid += (0xff & (unsigned char)buf[6]) << 16;
+	f->stid += (0xff & (unsigned char)buf[7]) <<  8;
+	f->stid += (0xff & (unsigned char)buf[8]);
 };
 
 static void


### PR DESCRIPTION
frame parse is not correctly, if the frame is long. 

```
######## h2tests/h2_1.vtc ########
Assert error in receive_frame(), vtc_http2.c line 416:
  Condition((f->data) != 0) not true.
**** top   0.0 macro def varnishd=varnishd
**** top   0.0 macro def varnishadm=varnishadm
**** top   0.0 macro def varnishstat=varnishstat
**** top   0.0 macro def varnishhist=varnishhist
**** top   0.0 macro def varnishlog=varnishlog
**** top   0.0 macro def varnishncsa=varnishncsa
**** top   0.0 macro def vmod_std=std
**** top   0.0 macro def vmod_debug=debug
**** top   0.0 macro def vmod_directors=directors
**** top   0.0 macro def pwd=/home/xcir/h2/org/tmp/Varnish-Cache-WIP-h2test/bin/varnishtest
**** top   0.0 macro def bad_ip=192.0.2.255
**** top   0.0 macro def tmpdir=/tmp/vtc.15068.1919e802
*    top   0.0 TEST h2tests/h2_1.vtc starting
**   top   0.0 === varnishtest "overflow"
*    top   0.0 TEST overflow
**   top   0.0 === h2server s1 {
**   s1    0.0 Starting server
**** s1    0.0 macro def s1_addr=127.0.0.1
**** s1    0.0 macro def s1_port=47798
**** s1    0.0 macro def s1_sock=127.0.0.1 47798
*    s1    0.0 Listen on 127.0.0.1 47798
**   top   0.0 === h2client c1  -connect ${s1_sock} {
**   c1    0.0 Starting client
**   s1    0.0 Started on 127.0.0.1 47798
**   c1    0.0 Waiting for client
***  c1    0.0 Connect to 127.0.0.1 47798
***  s1    0.0 accepted fd 5
***  c1    0.0 connected fd 6 from 127.0.0.1 51701 to 127.0.0.1 47798
**** c1    0.0 txpri| PRI * HTTP/2.0\r\n
**** c1    0.0 txpri| \r\n
**** c1    0.0 txpri| SM\r\n
**** c1    0.0 txpri| \r\n
***  s1    0.0 ============parsing extra stuff
**   s1    0.0 === stream 0 {
**   s1    0.0 Starting stream 0x7fca34000c40
**   s1    0.0 Waiting for stream 0
***  c1    0.0 ============parsing extra stuff
**   c1    0.0 === stream 0 {
**   c1    0.0 Starting stream 0x7fca2c000db0
**   s1    0.0 === txsettings
***  s1    0.0 tx: stream: 0, type: SETTINGS (4), flags: 0x00, size: 0
**   s1    0.0 === rxsettings
**   c1    0.0 Waiting for stream 0
**   c1    0.0 === txsettings
***  c1    0.0 tx: stream: 0, type: SETTINGS (4), flags: 0x00, size: 0
***  s1    0.0 rx: stream: 0, type: SETTINGS (4), flags: 0x00, size: 0
**   s1    0.0 === txsettings -ack
***  s1    0.0 tx: stream: 0, type: SETTINGS (4), flags: 0x01, size: 0
**   s1    0.0 === rxsettings
**   c1    0.0 === rxsettings
***  c1    0.0 rx: stream: 0, type: SETTINGS (4), flags: 0x00, size: 0
**   c1    0.0 === txsettings -ack
***  c1    0.0 tx: stream: 0, type: SETTINGS (4), flags: 0x01, size: 0
***  s1    0.0 rx: stream: 0, type: SETTINGS (4), flags: 0x01, size: 0
**   s1    0.0 === expect settings.ack == true
**** s1    0.0 (s0) EXPECT settings.ack (true) == "true" match
**   s1    0.0 Ending stream 0
**   s1    0.0 === stream 1 {
**   s1    0.0 Starting stream 0x7fca340017e0
**   c1    0.0 === rxsettings
**   s1    0.0 Waiting for stream 1
**   s1    0.0 === rxreq
***  c1    0.0 rx: stream: 0, type: SETTINGS (4), flags: 0x01, size: 0
**   c1    0.0 === expect settings.ack == true
**** c1    0.0 (s0) EXPECT settings.ack (true) == "true" match
**   c1    0.0 Ending stream 0
**   c1    0.0 === stream 1 {
**   c1    0.0 Starting stream 0x7fca2c0017f0
**   c1    0.0 Waiting for stream 1
**   c1    0.0 === txreq -req GET -url / -hdr :scheme http -hdr :authority loca...
***  c1    0.0 tx: stream: 1, type: HEADERS (1), flags: 0x05, size: 58
**   c1    0.0 === rxresp
***  s1    0.0 rx: stream: 1, type: HEADERS (1), flags: 0x05, size: 58
**** s1    0.0 s1 - header: :method : GET (0)
**** s1    0.0 s1 - header: :path : / (1)
**** s1    0.0 s1 - header: :scheme : http (2)
**** s1    0.0 s1 - header: :authority : localhost (3)
**   s1    0.0 === txresp -hdr long-header-original1 original1 \
***  s1    0.0 tx: stream: 1, type: HEADERS (1), flags: 0x05, size: 145
**   s1    0.0 Ending stream 1
***  c1    0.0 rx: stream: 1, type: HEADERS (1), flags: 0x05, size: -111 ###<-------- size is overflowed.####
***  s1    0.0 shutting fd 5
**   s1    0.0 Ending

#     top  TEST h2tests/h2_1.vtc FAILED (0.188) signal=6 exit=0
```