### PR TITLE
FIX: Check 31bit streamid

### DIFF
--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1321,7 +1321,7 @@ cmd_txgoaway(CMD_ARGS)
 		} else if (!strcmp(*av, "-laststream")) {
 			++av;
 			STRTOU32(ls, *av, p, vl, "-laststream");
-			if (ls >= (1 << 31)) {
+			if (ls & (1 << 31)) {
 				vtc_log(vl, 0, "-laststream must be a 31-bits integer "
 						"(found %s)", *av);
 			}
@@ -1750,7 +1750,7 @@ stream_new(const char *name, struct http2 *h)
 	s->ws = 0xffff;
 
 	STRTOU32(s->id, name, p, h->vl, "-some");
-	if (s->id >= (1 << 31))
+	if (s->id & (1 << 31))
 		vtc_log(h->vl, 0, "Stream id must be a 31-bits integer "
 				"(found %s)", name);
 


### PR DESCRIPTION
in my environment, `(1 << 31)` is `-2147483648`

this test case is passed...
https://gist.github.com/flano-yuki/bef0e5ee89f87847f37b

after fix
```
**   s1    0.0 === stream 2147483649 {
---- s1    0.0 Stream id must be a 31-bits integer (found 2147483649)
```