### PR TITLE
Featuer:txreq with priority and expect stream priority

### DIFF
--- a/bin/varnishtest/h2tests/h2_priority.vtc
+++ b/bin/varnishtest/h2tests/h2_priority.vtc
@@ -5,19 +5,19 @@ h2server s1 {
 		rxreq
 		txresp
 		expect stream.weight == 16
-		expect stream.stream == 0
+		expect stream.dependency == 0
 	} -run
 	stream 3 {
 		rxreq
 		txresp
 		expect stream.weight == 123
-		expect stream.stream == 5
+		expect stream.dependency == 5
 
 		rxprio
 		expect prio.weight == 10
 		expect prio.stream == 7
 		expect stream.weight == 10
-		expect stream.stream == 7
+		expect stream.dependency == 7
 	} -run
 } -start
 h2client c1 -connect ${s1_sock} {
@@ -25,26 +25,26 @@ h2client c1 -connect ${s1_sock} {
 		txreq -req GET -url /1 -hdr :scheme http -hdr :authority localhost
 		rxresp
 		expect stream.weight == 16
-		expect stream.stream == 0
+		expect stream.dependency == 0
 	} -run
 	stream 3 {
 		txreq -req GET -url /3 -hdr :scheme http -hdr :authority localhost \
-			-weight 123 -exclusive -stream 5
+			-weight 123 -exclusive -dependency 5
 		rxresp
 		expect stream.weight == 123
-		expect stream.stream == 5
+		expect stream.dependency == 5
 
 		txprio -weight 10 -stream 7
 		expect stream.weight == 10
-		expect stream.stream == 7
+		expect stream.dependency == 7
 	} -run
 	stream 5 {
 		expect stream.weight == 16
-		expect stream.stream == 0
+		expect stream.dependency == 0
 	} -run
 	stream 0 {
 		expect stream.weight == <undef>
-		expect stream.stream == <undef>
+		expect stream.dependency == <undef>
 	} -run
 } -run
 h2server s1 -wait

--- a/bin/varnishtest/h2tests/h2_priority.vtc
+++ b/bin/varnishtest/h2tests/h2_priority.vtc
@@ -1,0 +1,48 @@
+h2server s1 {        
+	stream 1 {
+		rxreq
+		txresp
+		expect stream.weight == 16
+		expect stream.stream == 0
+	} -run
+	stream 3 {
+		rxreq
+		txresp
+		expect stream.weight == 123
+		expect stream.stream == 5
+
+		rxprio
+		expect prio.weight == 10
+		expect prio.stream == 7
+		expect stream.weight == 10
+		expect stream.stream == 7
+	} -run
+} -start
+h2client c1 -connect ${s1_sock} {
+	stream 1 {
+		txreq -req GET -url /1 -hdr :scheme http -hdr :authority localhost
+		rxresp
+		expect stream.weight == 16
+		expect stream.stream == 0
+	} -run
+	stream 3 {
+		txreq -req GET -url /3 -hdr :scheme http -hdr :authority localhost \
+			-weight 123 -exclusive -stream 5
+		rxresp
+		expect stream.weight == 123
+		expect stream.stream == 5
+
+		txprio -weight 10 -stream 7
+		expect stream.weight == 10
+		expect stream.stream == 7
+	} -run
+	stream 5 {
+		expect stream.weight == 16
+		expect stream.stream == 0
+	} -run
+	stream 0 {
+		expect stream.weight == <undef>
+		expect stream.stream == <undef>
+	} -run
+} -run
+h2server s1 -wait

--- a/bin/varnishtest/h2tests/h2_priority.vtc
+++ b/bin/varnishtest/h2tests/h2_priority.vtc
@@ -1,3 +1,5 @@
+varnishtest "priority"
+
 h2server s1 {        
 	stream 1 {
 		rxreq

--- a/bin/varnishtest/h2tests/h2_priority2.vtc
+++ b/bin/varnishtest/h2tests/h2_priority2.vtc
@@ -1,0 +1,63 @@
+varnishtest "exclusive dependency"
+
+h2server s1 {        
+	stream 1 {
+		rxreq
+		txresp
+	} -run
+	stream 3 {
+		rxreq
+		txresp
+	} -run
+	stream 5 {
+		rxreq
+		txresp
+		expect stream.stream == 0
+	} -run
+
+	stream 1 {
+		expect stream.stream == 5
+	} -run
+	stream 3 {
+		expect stream.stream == 5
+	} -run
+
+	stream 1 {
+		rxprio
+	} -run
+	stream 5 {
+		expect stream.stream == 1
+	} -run
+
+} -start
+h2client c1 -connect ${s1_sock} {
+	stream 1 {
+		txreq
+		rxresp
+	} -run
+	stream 3 {
+		txreq
+		rxresp
+	} -run
+	stream 5 {
+		txreq -req GET -exclusive
+		expect stream.stream == 0
+		rxresp
+	} -run
+
+	stream 1 {
+		expect stream.stream == 5
+	} -run
+	stream 3 {
+		expect stream.stream == 5
+	} -run
+
+	stream 1 {
+		txprio -stream 0 -exclusive
+	} -run
+	stream 5 {
+		expect stream.stream == 1
+	} -run
+} -run
+
+h2server s1 -wait

--- a/bin/varnishtest/h2tests/h2_priority2.vtc
+++ b/bin/varnishtest/h2tests/h2_priority2.vtc
@@ -12,21 +12,21 @@ h2server s1 {
 	stream 5 {
 		rxreq
 		txresp
-		expect stream.stream == 0
+		expect stream.dependency == 0
 	} -run
 
 	stream 1 {
-		expect stream.stream == 5
+		expect stream.dependency == 5
 	} -run
 	stream 3 {
-		expect stream.stream == 5
+		expect stream.dependency == 5
 	} -run
 
 	stream 1 {
 		rxprio
 	} -run
 	stream 5 {
-		expect stream.stream == 1
+		expect stream.dependency == 1
 	} -run
 
 } -start
@@ -41,22 +41,22 @@ h2client c1 -connect ${s1_sock} {
 	} -run
 	stream 5 {
 		txreq -req GET -exclusive
-		expect stream.stream == 0
+		expect stream.dependency == 0
 		rxresp
 	} -run
 
 	stream 1 {
-		expect stream.stream == 5
+		expect stream.dependency == 5
 	} -run
 	stream 3 {
-		expect stream.stream == 5
+		expect stream.dependency == 5
 	} -run
 
 	stream 1 {
 		txprio -stream 0 -exclusive
 	} -run
 	stream 5 {
-		expect stream.stream == 1
+		expect stream.dependency == 1
 	} -run
 } -run
 

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1139,9 +1139,9 @@ cmd_tx11obj(CMD_ARGS)
 
 		vtc_log(s->hp->vl, 4, "s%lu - stream->dependency: %u", s->id, s->dependency);
 		vtc_log(s->hp->vl, 4, "s%lu - stream->weight: %u", s->id, s->weight);
-	}
-	if (exclusive){
-		exclusive_stream_dependency(s);
+		if (exclusive){
+			exclusive_stream_dependency(s);
+		}
 	}
 	f.data = buf;	
 	HPK_FreeIter(iter);

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -487,6 +487,8 @@ receive_frame(void *priv) {
 				if (exclusive) {
 					exclusive_stream_dependency(s);
 				}
+				vtc_log(hp->vl, 4, "s%lu - stream->dependency: %u", s->id, s->dependency);
+				vtc_log(hp->vl, 4, "s%lu - stream->weight: %u", s->id, s->weight);
 			}
 			iter = HPK_NewIter(s->hp->inctx, f->data + delta, f->size - delta);
 
@@ -1134,6 +1136,9 @@ cmd_tx11obj(CMD_ARGS)
 		*(uint32_t *)ubuf = htonl(stid | exclusive);
 		buf[4] = s->weight;
 		f.size += 5;
+
+		vtc_log(s->hp->vl, 4, "s%lu - stream->dependency: %u", s->id, s->dependency);
+		vtc_log(s->hp->vl, 4, "s%lu - stream->weight: %u", s->id, s->weight);
 	}
 	if (exclusive){
 		exclusive_stream_dependency(s);


### PR DESCRIPTION
This patch enables the txrep with priority and expect stream priority.

This changes include follows
- PRIORITY frame also changes the priority of stream.
- Priority with exclusive changes dependency of other streams.

like this
h2client
```
        stream 3 {
                txreq -req GET -url /3 -hdr :scheme http -hdr :authority localhost \
                        -weight 123 -exclusive -dependency 5
                rxresp
                expect stream.weight == 123
                expect stream.dependency == 5
        } -run
```
h2server
```
        stream 3 {
                rxreq
                txresp
                expect stream.weight == 123
                expect stream.dependency == 5
        } -run
```