### PR TITLE
Feature/noadd and scheme

### DIFF
--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1138,9 +1138,9 @@ cmd_tx11obj(CMD_ARGS)
 	hdr.key.huff = 0;
 	hdr.value.huff = 0;
 
-	if (!status_done) {
+	if (!status_done)
 		ENC(hdr, ":status", "200");
-	} if (!url_done)
+	if (!url_done)
 		ENC(hdr, ":path", "/");
 	if (!req_done)
 		ENC(hdr, ":method", "GET");

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1000,7 +1000,11 @@ cmd_tx11obj(CMD_ARGS)
 		hdr.value.huff = 0;
 		hdr.value.ptr = NULL;
 		hdr.value.len = 0;
-		if (!strcmp(*av, "-status") &&
+		if (!strcmp(*av, "-noadd")) {
+			url_done = 1;
+			status_done = 1;
+			req_done = 1;
+		} else if (!strcmp(*av, "-status") &&
 				!strcmp(cmd_str, "txresp")) {
 			ENC(hdr, ":status", av[1]);
 			av++;

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -961,6 +961,7 @@ cmd_tx11obj(CMD_ARGS)
 	int status_done = 1;
 	int req_done = 1;
 	int url_done = 1;
+	int scheme_done = 1;
 	uint32_t stid = 0;
 	uint32_t weight = 16;
 	int exclusive = 0;
@@ -985,6 +986,7 @@ cmd_tx11obj(CMD_ARGS)
 		if (!strcmp(cmd_str, "txreq")) {
 			req_done = 0;
 			url_done = 0;
+			scheme_done = 0;
 		} else {
 			status_done = 0;
 		}
@@ -1004,6 +1006,7 @@ cmd_tx11obj(CMD_ARGS)
 			url_done = 1;
 			status_done = 1;
 			req_done = 1;
+			scheme_done = 1;
 		} else if (!strcmp(*av, "-status") &&
 				!strcmp(cmd_str, "txresp")) {
 			ENC(hdr, ":status", av[1]);
@@ -1019,6 +1022,11 @@ cmd_tx11obj(CMD_ARGS)
 			ENC(hdr, ":method", av[1]);
 			av++;
 			req_done = 1;
+		} else if (!strcmp(*av, "-scheme") &&
+				!strcmp(cmd_str, "txreq")) {
+			ENC(hdr, ":scheme", av[1]);
+			av++;
+			scheme_done = 1;
 		} else if (!strcmp(*av, "-hdr")) {
 			ENC(hdr, av[1], av[2]);
 			av += 2;
@@ -1136,6 +1144,8 @@ cmd_tx11obj(CMD_ARGS)
 		ENC(hdr, ":path", "/");
 	if (!req_done)
 		ENC(hdr, ":method", "GET");
+	if (!scheme_done)
+		ENC(hdr, ":scheme", "http");
 
 	f.size = gethpk_iterLen(iter);
 	if (f.flags & PRIORITY){


### PR DESCRIPTION
I'll retry the p-r #4.
This p-r include 3 feature.
 - add -noadd option.
 - add -scheme option.
 - Pseudo header will check whether sent or not at -hdr, -idxHdr, litIdxHdr, -litHdr
