### PR TITLE
implementation INITIAL_WINDOW_SIZE

### DIFF
--- a/bin/varnishtest/h2tests/h2_initial_winsize.vtc
+++ b/bin/varnishtest/h2tests/h2_initial_winsize.vtc
@@ -1,0 +1,38 @@
+h2server s1 {
+	stream 0 {
+		rxsettings
+		txsettings -ack
+	} -run
+	stream 1 {
+		rxreq
+		txresp -bodylen 100
+	} -run
+	stream 0 {
+		rxsettings
+		txsettings -ack
+	} -run
+} -start
+
+h2client c1 -connect ${s1_sock} {
+	stream 0 {
+		txsettings -winsize 128
+		rxsettings
+	} -run
+	stream 1 {
+		txreq
+		rxresp
+		expect resp.bodylen == 100
+		expect stream.window == 28
+	} -run
+	stream 0 {
+		txsettings -winsize 64
+		rxsettings
+
+		expect stream.window == 65435
+	} -run
+	stream 1 {
+		expect stream.window == -36
+	} -run
+} -run
+
+h2server s1 -wait

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1351,10 +1351,11 @@ cmd_txsettings(CMD_ARGS)
 		else if (!strcmp(*av, "-winsize"))	{
 			PUT_KV(vl, winsize, val, 0x4);
 
-			VTAILQ_FOREACH(target, &hp->streams, list) {
+			AZ(pthread_mutex_lock(&hp->mtx));
+			VTAILQ_FOREACH(target, &hp->streams, list)
         			target->ws += (val - hp->iws);
-			}
 			hp->iws = val;
+			AZ(pthread_mutex_unlock(&hp->mtx));
 		}
 		else if (!strcmp(*av, "-framesize"))	{
 			PUT_KV(vl, framesize, val, 0x5);


### PR DESCRIPTION
This patch enables setting initial flow-control window size and increases/decreases window size of streams by using INITIAL_WINDOW_SIZE.

specification of INITIAL_WINDOW_SIZE is described in https://tools.ietf.org/html/rfc7540#section-6.9.2