### PR TITLE
Fix -all -some option

### DIFF
--- a/bin/varnishtest/h2tests/h2_continuation.vtc
+++ b/bin/varnishtest/h2tests/h2_continuation.vtc
@@ -1,0 +1,31 @@
+server s1 {
+	stream 1 {
+		rxreq
+		txresp -nohdrend
+		txcont -nohdrend -hdr "foo" "bar"
+		txcont           -hdr "baz" "qux"
+	} -run
+	stream 3 {
+		rxreq
+		txresp -nohdrend
+		txcont -nohdrend -hdr "foo2" "bar2"
+		txcont           -hdr "baz2" "qux2"
+	} -run
+} -start
+
+client c1 -connect ${s1_sock} {
+	stream 1 {
+		txreq
+		rxhdrs -all
+		expect resp.http.foo == "bar"
+		expect resp.http.baz == "qux"
+	} -run
+	stream 3 {
+		txreq
+		rxhdrs -some 2
+		expect resp.http.foo2 == "bar2"
+		expect resp.http.baz2 == "<undef>"
+	} -run
+} -run
+
+server s1 -wait

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1896,6 +1896,7 @@ cmd_rxhdrs(CMD_ARGS)
 
 	while (*++av) {
 		if (!strcmp(*av, "-some")) {
+			av++;
 			STRTOU32(times, *av, p, vl, "-some");
 			AN(times);
 		} else if (!strcmp(*av, "-all")) {
@@ -1906,7 +1907,7 @@ cmd_rxhdrs(CMD_ARGS)
 	if (*av != NULL)
 		vtc_log(vl, 0, "Unknown rxhdrs spec: %s\n", *av);
 
-	while (rcv++ < times || (loop && !(f->flags | END_HEADERS))) {
+	while (rcv++ < times || (loop && !(f->flags & END_HEADERS))) {
 		f = rxstuff(s);
 		if (!f)
 			return;
@@ -1932,6 +1933,7 @@ cmd_rxcont(CMD_ARGS)
 
 	while (*++av) {
 		if (!strcmp(*av, "-some")) {
+			av++;
 			STRTOU32(times, *av, p, vl, "-some");
 		} else if (!strcmp(*av, "-all")) {
 			loop = 1;
@@ -1941,7 +1943,7 @@ cmd_rxcont(CMD_ARGS)
 	if (*av != NULL)
 		vtc_log(vl, 0, "Unknown rxcont spec: %s\n", *av);
 
-	while (rcv++ < times || (loop && !(f->flags | END_HEADERS))) {
+	while (rcv++ < times || (loop && !(f->flags & END_HEADERS))) {
 		f = rxstuff(s);
 		if (!f)
 			return;
@@ -1980,6 +1982,7 @@ cmd_rxdata(CMD_ARGS)
 
 	while (*++av) {
 		if (!strcmp(*av, "-some")) {
+			av++;
 			STRTOU32(times, *av, p, vl, "-some");
 		} else if (!strcmp(*av, "-all")) {
 			loop = 1;
@@ -1989,7 +1992,7 @@ cmd_rxdata(CMD_ARGS)
 	if (*av != NULL)
 		vtc_log(vl, 0, "Unknown rxdata spec: %s\n", *av);
 
-	while (rcv++ < times || (loop && !(f->flags | END_STREAM))) {
+	while (rcv++ < times || (loop && !(f->flags & END_STREAM))) {
 		f = rxstuff(s);
 		if (!f)
 			return;
@@ -2032,7 +2035,7 @@ cmd_rxreqsp(CMD_ARGS)
 
 	end_stream = f->flags & END_STREAM;
 
-	while (!(f->flags | END_HEADERS)) {
+	while (!(f->flags & END_HEADERS)) {
 		f = rxstuff(s);
 		if (!f)
 			return;
@@ -2077,6 +2080,7 @@ cmd_rxpush(CMD_ARGS) {
 
 	while (*++av) {
 		if (!strcmp(*av, "-some")) {
+			av++;
 			STRTOU32(times, *av, p, vl, "-some");
 			AN(times);
 		} else if (!strcmp(*av, "-all")) {
@@ -2087,7 +2091,7 @@ cmd_rxpush(CMD_ARGS) {
 	if (*av != NULL)
 		vtc_log(vl, 0, "Unknown rxpush spec: %s\n", *av);
 
-	while (rcv++ < times || (loop && !(f->flags | END_HEADERS))) {
+	while (rcv++ < times || (loop && !(f->flags & END_HEADERS))) {
 		f = rxstuff(s);
 		if (!f)
 			return;


### PR DESCRIPTION
`-all` and `-some` options are does not work.

it's continue when `(f->flags & END_HEADERS)` == `0`.

and, using `-some` before fixing it.
```
---- c1    0.0 -some takes an integer as argument(found -some)
```

result of h2_continuation.vtc (before and after) 
https://gist.github.com/flano-yuki/a866d1516c4f3f6907ee735c2278aa98